### PR TITLE
move aria-hidden to connected callback to prevent Uncaught NotSupport…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "heroicons-wc",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "license": "MIT",
   "author": "Maël Obréjan <mael.obrejan@protonmail.com>",
   "description": "Heroicons as Web Components",

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -87,12 +87,14 @@ const build = async ({ className, tagName, svg, css }) => ({
       constructor() {
         super();
 
-        this.ariaHidden ??= "true";
-
         this.attachShadow({ mode: "open" }).innerHTML =
           '${utils.escapeSingleQuotes(
             `<style>${csso.minify(css).css}</style>${await minifyHtml(svg, { collapseWhitespace: true })}`,
           )}';
+      }
+
+      connectedCallback() {
+        this.ariaHidden ??= "true";
       }
     }
 


### PR DESCRIPTION
…edError: Failed to construct 'CustomElement': The result must not have attributes

I am literally not sure why this works but now i can include include heroicon files normally using webpack and my include.js file.  I will be using my fork until this is merged.